### PR TITLE
A-prime: fix Excel RAG chunking (0 chunks → 1346, retrieval verified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Financial Report Insights
 
-A privacy-first, local RAG (Retrieval-Augmented Generation) platform for CFO-grade financial analysis. Upload Excel or PDF financial reports and get interactive dashboards, 160+ financial ratios, scoring models, Monte Carlo simulations, and natural-language Q&A — all powered by Ollama and Sentence Transformers running entirely on your machine. No API keys, no cloud dependencies.
+A privacy-first, local RAG (Retrieval-Augmented Generation) platform for CFO-grade financial analysis. Upload Excel or PDF financial reports and get interactive dashboards, 160+ financial ratios, scoring models, Monte Carlo simulations, and natural-language Q&A — all powered by Ollama (LLM + embeddings) running entirely on your machine. No API keys, no cloud dependencies.
 
 ## Key Features
 
@@ -22,13 +22,13 @@ A privacy-first, local RAG (Retrieval-Augmented Generation) platform for CFO-gra
 | Language | Python 3.11+ |
 | UI | Streamlit |
 | LLM | Ollama (llama3.2 default) |
-| Embeddings | Sentence Transformers (all-MiniLM-L6-v2) |
+| Embeddings | Ollama (mxbai-embed-large, 1024-dim) |
 | Data | Pandas, NumPy, openpyxl, xlrd |
 | Visualization | Plotly |
 | Documents | PyMuPDF (PDF), python-docx (DOCX) |
 | Search | rank-bm25 + cosine similarity |
 | Config | Pydantic Settings |
-| Caching | joblib (embeddings), OrderedDict LRU (LLM responses) |
+| Caching | JSON content-hash (embeddings), OrderedDict LRU (LLM responses) |
 | Container | Docker (multi-stage, non-root, tini) |
 
 ## Prerequisites

--- a/financial-report-insights/docs/planning/findings.md
+++ b/financial-report-insights/docs/planning/findings.md
@@ -108,3 +108,24 @@
 3. **ML explainability** - SHAP required for ALL user-facing predictions
 4. **Eval visibility** - Surface confidence scores to users
 5. **Agent transparency** - Show agent activity as progress steps
+
+---
+
+## RAG Pipeline Audit Findings (2026-06-17, 4 read-only agents + adversarial swarm)
+
+Verified against source during the "A-prime" remediation (see progress.md; PR #48).
+
+**P0 (fixed):**
+- Excel `chunk_excel_sheet` emitted ~1200-token atomic blocks, never child chunks → ~11k-char chunks overflowing mxbai's 512-tok window, truncated to ~18% coverage.
+- `_count_tokens_approx` (`words*1.3`) under-counts markdown tables ~3x → "within budget" blocks overflow.
+- `_df_to_markdown` via pandas `to_markdown` → 82% empty-cell/alignment padding (embeds whitespace; ~5x volume).
+- Parent/child expansion (`_expand_parent_chunks`) was dead code — Excel chunks never set `chunk_level='child'`+`parent_id`+`parent_text`.
+- `.env OLLAMA_HOST=12434` (DMR, not running) → "0 chunks indexed"; live backend is Ollama 11434 (CPU-only, no GPU).
+
+**P1 (deferred):**
+- Eval harness non-functional as a gate: `enable_evaluation=False`, not in CI, synthetic golden Q&A referencing files absent from repo, can't detect truncation.
+- Vector index silently on O(n) `NumpyFlatIndex` (faiss/hnswlib not installed); RRF fusion keyed on fragile `id(doc)`; no similarity threshold; result `score` never set (avg_similarity always 0); index `.load()` doesn't validate dimension; BM25 over-aggressive stemming.
+
+**Infra:** Ollama's CPU embedding runner deadlocks under sustained load (`/v1/embeddings` hangs, `/api/ps` OK) → resumable embedder required.
+
+**Accepted risk:** if numeric recall stays weak after chunking fix, hybrid BM25/keyword retrieval is the #1 follow-up (general-purpose embedders may not distinguish e.g. 1,240 vs 1,420).

--- a/financial-report-insights/docs/planning/progress.md
+++ b/financial-report-insights/docs/planning/progress.md
@@ -42,3 +42,40 @@
 | Error | Attempt | Resolution |
 |-------|---------|------------|
 | (none) | | |
+
+---
+
+## Session: 2026-06-17 — RAG Chunking Remediation "A-prime" [COMPLETE, PR #48]
+
+### Trigger
+User reported launcher failing, then "0 chunks indexed" in the web UI.
+
+### Diagnosis (root causes)
+1. **Launcher:** killed `*streamlit*` by process name, but the server runs as `python.exe` → stale instance squatted port 8501. Fixed: kill the port OWNER by PID.
+2. **"0 chunks":** `.env OLLAMA_HOST=12434` (Docker Model Runner, not running) → every embed refused. Fixed → `11434` (Ollama, live backend on this machine).
+3. **Root retrieval defect (4-agent audit + adversarial swarm):** `chunk_excel_sheet` emitted ~1200-token atomic blocks (~11k chars) that overflowed mxbai's 512-tok window and were silently truncated to ~18% coverage; 82% of each chunk was empty-cell/alignment padding from `to_markdown`. Parent/child expansion was dead code.
+
+### Decision
+Expert swarm (5 lenses + 4 adversarial critics) → **"A-prime"**: fix chunking root cause, keep Ollama/mxbai, defer faiss + full eval-harness rebuild.
+
+### Implementation
+- `ingestion_pipeline._df_to_markdown` → dense rows (non-empty cells, no padding): 6.86M → 1.40M embed chars.
+- `document_chunker.chunk_excel_sheet` → small parent-child CHILD chunks sized to the embed window; `_count_tokens_approx` table-aware.
+- `local_llm` → warn-not-truncate, `max_batch_chars` 3000→12000, capped retry backoff.
+- Tests: row-conservation + child-invariant guards (61/61 pass).
+- `scripts/reembed_resumable.py` — checkpointed, hang-recovering bulk re-embed (Ollama CPU embed-runner deadlocks under load).
+- `evaluation/run_golden_qa.py` + `golden_financial_qa.py` (git-ignored, confidential) — real-content gate.
+
+### Result
+609 oversized chunks → **1346 children** (max 1689 ch, 0 over window), rows conserved 4377==4377. **Gate PASS: TOP1 10/12, TOP3 12/12, DEEP-TOP1 4/4.** App live on 8501. Commits c821c92 + 2259da8 → PR #48 (base = integration branch).
+
+### Errors Encountered
+| Error | Resolution |
+|-------|------------|
+| Ollama `/v1/embeddings` deadlock under sustained CPU load | resumable embedder: checkpoint + auto-restart Ollama + resume |
+| Re-embed est. 10-25 min was really ~5h | measured volume/throughput first; dense rendering cut content ~5x → ~50 min |
+
+### Deferred follow-ups
+- Hybrid BM25/keyword retrieval if numeric recall proves weak (pre-agreed #1).
+- Eval-harness rebuild (currently gated off / synthetic goldens / not in CI); RRF `id(doc)` fragility; similarity threshold; optional faiss-cpu.
+- `/clarity-gate` (pre-ingestion epistemic-quality gate) — parked.

--- a/financial-report-insights/document_chunker.py
+++ b/financial-report-insights/document_chunker.py
@@ -56,8 +56,18 @@ def _generate_chunk_id(source: str, section: str, index) -> str:
     return hashlib.sha256(key.encode()).hexdigest()[:16]
 
 
-def _count_tokens_approx(text: str) -> int:
-    """Approximate token count (words * 1.3 for English text)."""
+def _count_tokens_approx(text: str, is_table: bool = False) -> int:
+    """Approximate token count.
+
+    Prose: words * 1.3 (English heuristic).
+    Tables/markdown (``is_table=True``): a word-based count under-estimates
+    table content ~3x because digits, punctuation and pipe separators each
+    split into their own WordPiece tokens. Use a conservative char-based
+    estimate (~3 chars/token) instead, so table chunks stay safely under the
+    embedder's 512-token window rather than overflowing and being truncated.
+    """
+    if is_table:
+        return len(text) // 3 + 1
     return int(len(text.split()) * 1.3)
 
 
@@ -315,106 +325,123 @@ def chunk_table(
     )
 
 
+# Excel chunk sizing (REAL tokens, table-aware count). Children are the units
+# actually embedded and must fit mxbai's 512-token window once the nl_description
+# prefix (~60 tokens) is prepended at embed time, so the child text target leaves
+# headroom. Parents are larger context units swapped in at retrieval time.
+EXCEL_CHILD_TOKEN_TARGET = 350
+EXCEL_PARENT_TOKEN_TARGET = 1100
+EXCEL_MAX_PARENT_CHARS = 6000  # cap parent_text injected into the LLM prompt
+
+
 def chunk_excel_sheet(
     df_markdown: str,
     source: str,
     sheet_name: str,
     section_type: str = "general",
     metadata: Optional[Dict[str, Any]] = None,
+    child_token_target: int = EXCEL_CHILD_TOKEN_TARGET,
+    parent_token_target: int = EXCEL_PARENT_TOKEN_TARGET,
 ) -> List[RAGChunk]:
-    """Chunk an Excel sheet rendered as markdown.
+    """Chunk an Excel sheet rendered as markdown into parent-child chunks.
 
-    Treats the sheet as a table-heavy document. Small sheets become
-    atomic table chunks; large sheets get parent-child splitting
-    while respecting row boundaries.
+    Every sheet is split into small CHILD chunks sized to the embedder's token
+    window (table-aware count) and grouped under larger PARENT context blocks.
+    Only children are emitted for
+    embedding/indexing; each child carries ``parent_id`` + ``parent_text`` so
+    ``_expand_parent_chunks`` can swap in the richer parent context at retrieval
+    time. This replaces the old behaviour where sheets became single ~1200-token
+    atomic blocks that overflowed the 512-token window and were silently
+    truncated to ~18% coverage.
 
     Args:
-        df_markdown: Sheet content as markdown table.
+        df_markdown: Sheet content as a (dense) markdown table.
         source: Source file name.
         sheet_name: Excel sheet name.
         section_type: Detected financial section type.
         metadata: Additional metadata.
+        child_token_target: Target real-token size of child table text.
+        parent_token_target: Target real-token size of parent context blocks.
 
     Returns:
-        List of RAGChunk objects.
+        List of child RAGChunk objects (chunk_level == "child").
     """
     meta = metadata or {}
     meta["sheet_name"] = sheet_name
 
-    tokens = _count_tokens_approx(df_markdown)
+    # _df_to_markdown emits one dense row-record per line (non-empty cells only,
+    # no table header/separator). Treat each non-blank line as one row.
+    rows = [ln for ln in df_markdown.split("\n") if ln.strip()]
+    if not rows:
+        return []
 
-    # Small sheets -> atomic table chunk
-    if tokens <= 1500:
-        return [chunk_table(
-            df_markdown,
-            source=source,
-            section_type=section_type,
-            section_title=sheet_name,
-            metadata=meta,
-        )]
+    # 1) Group rows into PARENT context blocks (row boundaries preserved).
+    parent_blocks: List[List[str]] = []
+    cur_rows: List[str] = []
+    cur_tokens = 0
+    for row in rows:
+        rt = _count_tokens_approx(row, is_table=True)
+        if cur_rows and cur_tokens + rt > parent_token_target:
+            parent_blocks.append(cur_rows)
+            cur_rows = []
+            cur_tokens = 0
+        cur_rows.append(row)
+        cur_tokens += rt
+    if cur_rows:
+        parent_blocks.append(cur_rows)
 
-    # Large sheets -> split by rows while keeping header
-    lines = df_markdown.split("\n")
-    # Find header rows (first 2-3 lines of a markdown table)
-    header_lines: List[str] = []
-    data_lines: List[str] = []
-    header_done = False
-
-    for i, line in enumerate(lines):
-        if not header_done:
-            header_lines.append(line)
-            # Header separator line (e.g., |---|---|---|)
-            if re.match(r"^\s*\|[\s\-:]+\|", line):
-                header_done = True
-        else:
-            data_lines.append(line)
-
-    if not data_lines:
-        # No clear table structure, fall back to text chunking
-        return chunk_text_content(
-            df_markdown,
-            source=source,
-            section_type=section_type,
-            section_title=sheet_name,
-            metadata=meta,
-        )
-
-    header_text = "\n".join(header_lines)
     chunks: List[RAGChunk] = []
-    current_rows: List[str] = []
-    current_tokens = _count_tokens_approx(header_text)
-    chunk_idx = 0
-    parent_target = 1200
+    multi_part = len(parent_blocks) > 1
 
-    for row in data_lines:
-        row_tokens = _count_tokens_approx(row)
-        if current_tokens + row_tokens > parent_target and current_rows:
-            block_text = header_text + "\n" + "\n".join(current_rows)
-            table_chunk = chunk_table(
-                block_text,
+    # 2) Split each parent block into CHILD chunks sized to the embed window.
+    #    Children carry only their own rows (no repeated header); the
+    #    nl_description prefix added at embed time supplies sheet/section context.
+    for p_idx, p_rows in enumerate(parent_blocks):
+        title = f"{sheet_name} (part {p_idx + 1})" if multi_part else sheet_name
+        parent_id = _generate_chunk_id(source, f"{sheet_name}:parent", p_idx)
+        parent_text = "\n".join(p_rows)
+        if len(parent_text) > EXCEL_MAX_PARENT_CHARS:
+            parent_text = parent_text[:EXCEL_MAX_PARENT_CHARS]
+
+        # Sub-group the parent's rows into child-sized blocks.
+        child_groups: List[List[str]] = []
+        cur_child: List[str] = []
+        cur_child_tokens = 0
+        for row in p_rows:
+            rt = _count_tokens_approx(row, is_table=True)
+            if cur_child and cur_child_tokens + rt > child_token_target:
+                child_groups.append(cur_child)
+                cur_child = []
+                cur_child_tokens = 0
+            cur_child.append(row)
+            cur_child_tokens += rt
+        if cur_child:
+            child_groups.append(cur_child)
+
+        for child_idx, child_rows in enumerate(child_groups):
+            child_text = "\n".join(child_rows)
+            child_id = _generate_chunk_id(
+                source, f"{sheet_name}:child", f"{p_idx}-{child_idx}",
+            )
+            child = RAGChunk(
+                chunk_id=child_id,
+                text=child_text,
+                parent_id=parent_id,
+                parent_text=parent_text,
                 source=source,
                 section_type=section_type,
-                section_title=f"{sheet_name} (part {chunk_idx + 1})",
-                metadata={**meta, "part_index": chunk_idx},
+                section_title=title,
+                is_table=True,
+                metadata={
+                    **meta,
+                    "chunk_level": "child",
+                    "part_index": p_idx,
+                    "child_index": child_idx,
+                },
             )
-            chunks.append(table_chunk)
-            chunk_idx += 1
-            current_rows = []
-            current_tokens = _count_tokens_approx(header_text)
-
-        current_rows.append(row)
-        current_tokens += row_tokens
-
-    # Flush remaining
-    if current_rows:
-        block_text = header_text + "\n" + "\n".join(current_rows)
-        table_chunk = chunk_table(
-            block_text,
-            source=source,
-            section_type=section_type,
-            section_title=f"{sheet_name} (part {chunk_idx + 1})" if chunk_idx > 0 else sheet_name,
-            metadata={**meta, "part_index": chunk_idx},
-        )
-        chunks.append(table_chunk)
+            child.nl_description = _generate_nl_description(
+                child_text, section_type, title, source,
+            )
+            chunks.append(child)
 
     return chunks

--- a/financial-report-insights/evaluation/.gitignore
+++ b/financial-report-insights/evaluation/.gitignore
@@ -1,0 +1,3 @@
+# Golden Q&A is generated from a private workbook (real financial figures + PII).
+# Never commit it; regenerate per deployment from your own documents.
+golden_financial_qa.py

--- a/financial-report-insights/evaluation/run_golden_qa.py
+++ b/financial-report-insights/evaluation/run_golden_qa.py
@@ -1,0 +1,89 @@
+"""Run the real-content golden Q&A retrieval eval against the live RAG.
+
+Unlike the synthetic eval harness (which scores filename matches against files
+that don't exist in the repo), this gate is grounded in the ACTUAL workbook:
+each question's distinctive figure must appear in the chunk that retrieval
+returns. Several questions deliberately target rows far into their sheet
+(char_offset > 2500), which the old truncate-to-~18% ingestion could not have
+surfaced -- so a pass here proves the dense-chunking fix actually improved
+coverage, not just that numbers appear somewhere.
+
+Run from the financial-report-insights dir:
+    ./.venv/Scripts/python.exe -m evaluation.run_golden_qa
+Exit code 0 = gate passed, 1 = failed.
+"""
+
+import sys
+
+from app_local import SimpleRAG
+from config import settings
+
+try:
+    # golden_financial_qa.py holds figures extracted from a private workbook and
+    # is intentionally git-ignored; generate it per deployment from real docs.
+    from evaluation.golden_financial_qa import GOLDEN
+except ImportError:
+    print(
+        "No evaluation/golden_financial_qa.py found. This gate needs a golden set "
+        "built from your own documents (see the module that authored it). Skipping."
+    )
+    sys.exit(0)
+
+# Gate thresholds.
+MIN_TOP1 = 8            # >= this many of 12 with the figure in the TOP chunk
+MIN_DEEP_FRACTION = 0.5  # >= half the deep questions must hit top-1
+
+
+def _haystack(doc: dict) -> str:
+    """Text a retrieved doc exposes: expanded content + original child text."""
+    parts = [str(doc.get("content", ""))]
+    if doc.get("_child_content"):
+        parts.append(str(doc["_child_content"]))
+    return "\n".join(parts)
+
+
+def main() -> int:
+    rag = SimpleRAG(
+        docs_folder="./documents",
+        embedding_model=settings.embedding_model,
+    )
+    n_chunks = len(rag.documents)
+    print(f"index: {n_chunks} chunks indexed")
+    if n_chunks == 0:
+        print("GATE FAIL (no chunks indexed)")
+        return 1
+
+    top1 = top3 = 0
+    deep_top1 = deep_total = 0
+    rows = []
+    for g in GOLDEN:
+        results = rag.retrieve(g["question"], top_k=3) or []
+        val = str(g["expected_value"])
+        in_top1 = bool(results) and val in _haystack(results[0])
+        in_top3 = any(val in _haystack(r) for r in results)
+        top1 += in_top1
+        top3 += in_top3
+        if g.get("deep"):
+            deep_total += 1
+            deep_top1 += in_top1
+        rows.append((g.get("deep", False), in_top1, in_top3, g["sheet"], g["label"], val))
+
+    n = len(GOLDEN)
+    for deep, t1, t3, sheet, label, val in rows:
+        tag = "DEEP" if deep else "    "
+        print(
+            f"  {tag} top1={'Y' if t1 else 'N'} top3={'Y' if t3 else 'N'}  "
+            f"[{sheet}] {label} = {val}"
+        )
+    print(f"\nTOP1 {top1}/{n}   TOP3 {top3}/{n}   DEEP-TOP1 {deep_top1}/{deep_total}")
+
+    passed = top1 >= MIN_TOP1 and (
+        deep_total == 0 or deep_top1 >= deep_total * MIN_DEEP_FRACTION
+    )
+    print("GATE", "PASS" if passed else "FAIL",
+          f"(need TOP1>={MIN_TOP1} and DEEP-TOP1>={int(deep_total * MIN_DEEP_FRACTION)})")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/financial-report-insights/ingestion_pipeline.py
+++ b/financial-report-insights/ingestion_pipeline.py
@@ -9,6 +9,7 @@ Integrates with SimpleRAG's document/embedding stores.
 """
 
 import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -133,30 +134,52 @@ def _find_label_column(df: pd.DataFrame) -> Optional[int]:
     return best_col if best_score > 3 else None
 
 
-def _df_to_markdown(df: pd.DataFrame, max_rows: int = 200) -> str:
-    """Convert a DataFrame to markdown table format.
+def _is_meaningful_header(name: str) -> bool:
+    """True if a column header carries semantic meaning worth embedding.
 
-    Limits to max_rows to prevent extremely large chunks.
+    Excel exports without a header band become ``Unnamed: N`` (renamed to
+    ``Col_N`` upstream); attaching those to every value is pure noise, so we
+    emit value-only for them and ``Header: value`` only for real labels.
+    """
+    s = str(name).strip()
+    if not s:
+        return False
+    if re.match(r"^(unnamed|col)[\s_:]*\d*$", s, re.IGNORECASE):
+        return False
+    return bool(re.search(r"[A-Za-z]", s))
+
+
+def _df_to_markdown(df: pd.DataFrame, max_rows: int = 200) -> str:
+    """Render a DataFrame densely: one line per row, non-empty cells only.
+
+    On sparse financial sheets, ``to_markdown`` pads every cell to column width
+    and emits all NaN cells, so ~80% of the output is whitespace/pipe padding
+    that both dilutes embeddings and inflates the volume to embed ~5x. This form
+    drops empty cells and alignment padding entirely: each row becomes its
+    non-empty cells joined by `` | ``, with the column name attached only when
+    it is a real label (``Header: value``), else value-only. Downstream chunking
+    treats each line as one row record. Limits to max_rows to bound volume.
     """
     if df.empty:
         return ""
 
-    # Truncate if needed
-    truncated = df.head(max_rows)
+    df = df.dropna(axis=1, how="all").dropna(axis=0, how="all")
+    if df.empty:
+        return ""
+    df = df.head(max_rows)
 
-    try:
-        return truncated.to_markdown(index=False)
-    except Exception as exc:
-        logger.debug("to_markdown fallback: %s", exc)
-        # Fallback: simple pipe-delimited format
-        lines = []
-        headers = [str(c) for c in truncated.columns]
-        lines.append("| " + " | ".join(headers) + " |")
-        lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
-        for _, row in truncated.iterrows():
-            vals = [str(v) if pd.notna(v) else "" for v in row]
-            lines.append("| " + " | ".join(vals) + " |")
-        return "\n".join(lines)
+    headers = [str(c) for c in df.columns]
+    meaningful = [_is_meaningful_header(h) for h in headers]
+    lines: List[str] = []
+    for _, row in df.iterrows():
+        cells: List[str] = []
+        for header, is_named, value in zip(headers, meaningful, row):
+            if pd.notna(value) and str(value).strip() != "":
+                val = str(value).strip()
+                cells.append(f"{header}: {val}" if is_named else val)
+        if cells:
+            lines.append(" | ".join(cells))
+    return "\n".join(lines)
 
 
 def ingest_excel(

--- a/financial-report-insights/local_llm.py
+++ b/financial-report-insights/local_llm.py
@@ -460,15 +460,29 @@ class LocalEmbedder:
                 "Embedder dimension not initialized. Ensure embedding service is "
                 "available and wait_for_embedding_service() has completed."
             )
-        # mxbai-embed-large via DMR: ~512 token context per text, ~4K total batch tokens
+        # mxbai-embed-large: ~512-token context per text. Chunking sizes inputs
+        # to fit, but guard here rather than truncating silently.
         max_chars = 2500
-        max_batch_chars = 3000
+        # Real batching: well-sized chunks are ~1-1.5k chars, so a larger char
+        # budget lets many pack into one request (the item cap then binds) instead
+        # of the old ~1-chunk-per-request that drove ingestion wall-clock.
+        max_batch_chars = 12000
+        window_chars = 1800  # ~512 tokens of dense table text
         # Item-count cap from config (default 32) prevents unbounded batch sizes
         try:
             from config import settings as _cfg
             max_batch_items = _cfg.embedding_batch_size
         except (ImportError, AttributeError):
             max_batch_items = 32
+        # Surface (don't hide) inputs that overflow the model window and will be
+        # truncated by the server -> signals chunk sizing needs tightening.
+        _oversize = sum(1 for t in texts if len(t) > window_chars)
+        if _oversize:
+            logger.warning(
+                "%d/%d embed inputs exceed ~%d chars (~512-token window) and will be "
+                "truncated by the model; chunk sizing may need tightening",
+                _oversize, len(texts), window_chars,
+            )
         safe_texts = [t[:max_chars] if len(t) > max_chars else t for t in texts]
         # Sanitize text: replace NUL bytes and non-UTF8 that crash DMR tokenizer
         safe_texts = [
@@ -538,7 +552,8 @@ class LocalEmbedder:
                     ) from exc
             except httpx.RequestError as e:
                 if attempt < max_retries:
-                    wait = 2 ** attempt
+                    wait = min(2 ** attempt, 8)  # cap backoff so a transient blip
+                    # can't stack into a multi-minute apparent hang
                     logger.warning(
                         "Embedding network error (attempt %d/%d, batch=%d texts), "
                         "retrying in %ds: %s",
@@ -549,7 +564,7 @@ class LocalEmbedder:
                 raise
             except httpx.HTTPStatusError as e:
                 if e.response.status_code >= 500 and attempt < max_retries:
-                    wait = 2 ** attempt  # 2s, 4s, 8s, 16s
+                    wait = min(2 ** attempt, 8)  # capped backoff (see above)
                     logger.warning(
                         "Embedding 5xx error (attempt %d/%d, batch=%d texts), "
                         "retrying in %ds: %s",

--- a/financial-report-insights/scripts/reembed_resumable.py
+++ b/financial-report-insights/scripts/reembed_resumable.py
@@ -1,0 +1,184 @@
+"""Resumable, hang-resistant bulk re-embed for the financial RAG index.
+
+Ollama's CPU embedding runner can deadlock under sustained load: the
+/v1/embeddings endpoint stops responding (HTTP 000) while /api/ps still
+answers, and the in-process embedder blocks forever. Because SimpleRAG only
+writes its embedding cache once the WHOLE file finishes, a single hang loses
+all progress.
+
+This script embeds the workbook's chunks in small batches, checkpoints every
+batch to disk, and on a hang restarts Ollama and resumes from the checkpoint --
+so the job always completes. When done it writes the SimpleRAG embedding cache
+(.cache/embeddings/<key>.json) so the app loads the index instantly with no
+re-embedding.
+
+Run from the financial-report-insights dir:
+    ./.venv/Scripts/python.exe scripts/reembed_resumable.py
+"""
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+# Run from anywhere: put the app dir (parent of scripts/) on the import path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config import settings  # noqa: E402
+from ingestion_pipeline import chunks_to_documents, ingest_file  # noqa: E402
+
+OLLAMA = "http://localhost:11434"
+URL = f"{OLLAMA}/v1/embeddings"
+MODEL = settings.embedding_model
+BATCH = 4                    # small batches reduce Ollama CPU deadlock risk
+REQ_TIMEOUT = 45.0          # per-request; shorter than a true hang
+MAX_CHARS = 2500            # match LocalEmbedder truncation
+CACHE_DIR = Path(settings.embedding_cache_dir)
+PROGRESS = CACHE_DIR / "_reembed_progress.json"
+# Resolve the shell to a full path (avoids PATH-hijack; satisfies ruff S607).
+_PWSH = shutil.which("powershell") or shutil.which("pwsh") or "powershell"
+
+
+def _docs_for_workbook():
+    f = next(Path("documents").glob("*.xlsx"))
+    docs = chunks_to_documents(ingest_file(f))
+    # SimpleRAG cache key: sha256(name:content_hash:model)
+    h = hashlib.sha256()
+    with open(f, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    key_str = f"{f.name}:{h.hexdigest()}:{MODEL}"
+    cache_key = hashlib.sha256(key_str.encode()).hexdigest()
+    return f, docs, cache_key
+
+
+def _sanitize(text: str) -> str:
+    text = text[:MAX_CHARS]
+    return text.replace("\x00", "").encode("utf-8", errors="replace").decode("utf-8")
+
+
+def _ollama_up() -> bool:
+    try:
+        return httpx.get(f"{OLLAMA}/api/tags", timeout=5).status_code == 200
+    except Exception:
+        return False
+
+
+def _restart_ollama():
+    print("  ! restarting Ollama (cleared wedged embed runner)...", flush=True)
+    # All args are hardcoded constants (no untrusted input) -> S603 suppressed.
+    subprocess.run(  # noqa: S603
+        [_PWSH, "-NoProfile", "-Command",
+         "Get-Process ollama -ErrorAction SilentlyContinue | Stop-Process -Force"],
+        capture_output=True,
+    )
+    time.sleep(3)
+    subprocess.Popen(  # noqa: S603
+        [_PWSH, "-NoProfile", "-Command",
+         "Start-Process ollama -ArgumentList serve -WindowStyle Hidden"],
+    )
+    for _ in range(20):
+        if _ollama_up():
+            break
+        time.sleep(2)
+    # warm the model back up
+    try:
+        httpx.post(URL, json={"model": MODEL, "input": ["warm"]}, timeout=60)
+    except Exception as exc:
+        print(f"  (post-restart warm-up failed, continuing: {exc})", flush=True)
+    time.sleep(1)
+
+
+def _embed_one_batch(texts):
+    """Embed a small batch; raises on timeout/non-200 so caller can recover."""
+    with httpx.Client(timeout=REQ_TIMEOUT) as c:
+        r = c.post(URL, json={"model": MODEL, "input": texts})
+        r.raise_for_status()
+        return [d["embedding"] for d in r.json()["data"]]
+
+
+def main() -> int:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    f, docs, cache_key = _docs_for_workbook()
+    n = len(docs)
+    texts = [_sanitize(d["content"]) for d in docs]
+    print(f"workbook={f.name}  chunks={n}  cache_key={cache_key[:12]}", flush=True)
+
+    # Resume from checkpoint if present.
+    embeddings = [None] * n
+    done = 0
+    if PROGRESS.exists():
+        try:
+            saved = json.loads(PROGRESS.read_text())
+            if saved.get("n") == n and saved.get("cache_key") == cache_key:
+                for i, e in enumerate(saved["embeddings"]):
+                    embeddings[i] = e
+                done = sum(1 for e in embeddings if e is not None)
+                print(f"resumed from checkpoint: {done}/{n} already embedded", flush=True)
+        except Exception as exc:
+            print(f"(ignoring unreadable checkpoint: {exc})", flush=True)
+
+    if not _ollama_up():
+        _restart_ollama()
+
+    t0 = time.time()
+    i = 0
+    while i < n:
+        if embeddings[i] is not None:
+            i += 1
+            continue
+        # build next batch of not-yet-done items
+        batch_idx = []
+        j = i
+        while j < n and len(batch_idx) < BATCH:
+            if embeddings[j] is None:
+                batch_idx.append(j)
+            j += 1
+        batch_texts = [texts[k] if texts[k].strip() else " " for k in batch_idx]
+
+        ok = False
+        for attempt in range(1, 5):
+            try:
+                vecs = _embed_one_batch(batch_texts)
+                for k, v in zip(batch_idx, vecs):
+                    embeddings[k] = v
+                ok = True
+                break
+            except Exception as exc:
+                print(f"  batch at {batch_idx[0]} failed (attempt {attempt}): "
+                      f"{type(exc).__name__}", flush=True)
+                _restart_ollama()
+        if not ok:
+            print(f"FATAL: could not embed batch at {batch_idx[0]} after retries", flush=True)
+            return 1
+
+        done += len(batch_idx)
+        i = batch_idx[-1] + 1
+        # checkpoint every ~20 batches
+        if done % (BATCH * 20) < BATCH or done >= n:
+            PROGRESS.write_text(json.dumps(
+                {"n": n, "cache_key": cache_key, "embeddings": embeddings}))
+            rate = done / max(time.time() - t0, 1e-6)
+            eta = (n - done) / max(rate, 1e-6) / 60
+            print(f"  {done}/{n}  ({rate:.1f}/s, ETA {eta:.0f} min)", flush=True)
+
+    # Fill any empty-text slots with zero vectors (consistent w/ app behavior).
+    dim = len(next(e for e in embeddings if e))
+    embeddings = [e if e is not None else [0.0] * dim for e in embeddings]
+
+    # Write the SimpleRAG cache: [documents, embeddings].
+    out = CACHE_DIR / f"{cache_key}.json"
+    out.write_text(json.dumps([docs, embeddings]))
+    PROGRESS.unlink(missing_ok=True)
+    print(f"DONE wrote {out.name}  ({n} embeddings, dim={dim}) in "
+          f"{time.time() - t0:.0f}s", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/financial-report-insights/tests/test_document_chunker.py
+++ b/financial-report-insights/tests/test_document_chunker.py
@@ -194,3 +194,51 @@ class TestChunkExcelSheet:
         # Implementation: chunk_table on empty string still creates a chunk
         # but chunk_excel_sheet checks token count
         assert len(chunks) >= 0  # May be 0 or 1 depending on implementation
+
+
+class TestExcelChunkInvariants:
+    """Guards for the dense parent-child Excel chunking (A-prime)."""
+
+    def _rows(self, n: int) -> str:
+        # One dense row-record per line, varied widths to force multiple
+        # parent/child splits.
+        return "\n".join(
+            f"Line Item {i}: {i * 100} | {i * 7} | week {i % 13} | note-{i}"
+            for i in range(n)
+        )
+
+    def test_row_conservation(self):
+        """Every input row appears in exactly one child chunk (no drop/dup).
+
+        This is the only guard against silently dropping a financial line item.
+        """
+        from collections import Counter
+
+        rows = self._rows(120)
+        chunks = chunk_excel_sheet(rows, source="cf.xlsx", sheet_name="Forecast")
+        expected = Counter(ln for ln in rows.split("\n") if ln.strip())
+        got = Counter(
+            ln
+            for c in chunks
+            for ln in c.text.split("\n")
+            if ln.strip()
+        )
+        assert got == expected, "rows dropped or duplicated across children"
+
+    def test_children_have_parent_links(self):
+        """All emitted chunks are children carrying parent_id + parent_text."""
+        chunks = chunk_excel_sheet(self._rows(120), source="cf.xlsx", sheet_name="F")
+        assert len(chunks) > 1  # 120 varied rows must split into multiple children
+        for c in chunks:
+            assert c.metadata.get("chunk_level") == "child"
+            assert c.parent_id
+            assert c.parent_text
+
+    def test_children_fit_embed_window(self):
+        """Child text stays within the ~512-token embed window (table-aware)."""
+        chunks = chunk_excel_sheet(self._rows(200), source="cf.xlsx", sheet_name="F")
+        for c in chunks:
+            # table-aware estimate must leave headroom under 512 for the
+            # nl_description prefix added at embed time
+            assert _count_tokens_approx(c.text, is_table=True) <= 512
+            assert len(c.parent_text or "") <= 6000  # EXCEL_MAX_PARENT_CHARS


### PR DESCRIPTION
## Summary

Fixes the financial RAG so the workbook actually indexes and retrieves correctly. Two layers were broken:

1. **Surface:** `.env` pointed embeddings at Docker Model Runner (`:12434`, not running) → every embed failed → **"0 chunks indexed."** Repointed to the running Ollama (`:11434`).
2. **Root cause:** Excel sheets became ~11k-char chunks that overflowed `mxbai-embed-large`'s 512-token window and were silently truncated to **~18% coverage**; **82% of every chunk was empty-cell/alignment padding** from `to_markdown`. Embeddings encoded mostly whitespace, so deep figures were unretrievable.

## Changes

- **`ingestion_pipeline._df_to_markdown`** — dense row rendering (non-empty cells only, no alignment padding, meaningful-header prefixing). Embed volume **6.86M → 1.40M chars**.
- **`document_chunker.chunk_excel_sheet`** — split every sheet into small **child** chunks sized to the embed window (table-aware token count) under larger **parent** context blocks; sets `chunk_level`/`parent_id`/`parent_text` so `_expand_parent_chunks` finally works. No more oversized atomic blocks.
- **`document_chunker._count_tokens_approx`** — table-aware (char-based) counting; `words*1.3` under-counted markdown tables ~3x.
- **`local_llm`** — warn (instead of silently truncating) on inputs over the window; raise `max_batch_chars` 3000→12000 for real batching; cap retry backoff.
- **Tests** — row-conservation guard (no financial line item dropped) + child-invariant guards.
- **Tooling** — `scripts/reembed_resumable.py` (checkpointed, hang-recovering bulk re-embed — see note) and `evaluation/run_golden_qa.py` (real-content retrieval gate).

## Results

| | Before | After |
|---|---|---|
| Chunks | 609 oversized (avg 11,263 ch) | 1346 children (max 1689 ch, **0 over window**) |
| Coverage | ~18% of each chunk embedded | full content, padding removed |
| Row conservation | — | 4377 == 4377 (no row dropped) |

**Retrieval gate (real workbook):** `TOP1 10/12, TOP3 12/12, DEEP-TOP1 4/4` — all four deep-row questions (figures past char 2500, which the old pipeline couldn't surface) retrieve correctly.

## Verification

- `pytest`: 61/61 chunker+ingestion, 237 in the embedding/retrieval regression subset, 0 failures. (3 unrelated pre-existing collection errors from missing `sklearn`/`statsmodels`.)
- `ruff`: no new lint categories; new tooling files clean.
- No secrets; no stray `print`/`pdb`.

## Notes

- **Ollama CPU embed-runner deadlock:** under sustained bulk embedding, Ollama's `/v1/embeddings` hangs while `/api/ps` stays up. Since SimpleRAG only caches after a whole file finishes, a hang lost all progress. `reembed_resumable.py` works around it (small batches, checkpoint every ~80, auto-restart Ollama + resume). Full re-embed ~50 min on CPU.
- **Confidential data kept out of git:** the golden Q&A set (`evaluation/golden_financial_qa.py`) holds real figures from a private workbook and is git-ignored; the gate runner skips cleanly when it's absent.
- **Deferred:** if numeric recall proves weak in use, hybrid BM25/keyword retrieval is the next step; lower-priority audit items remain (eval-harness rebuild, RRF `id(doc)` fragility, similarity threshold).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
